### PR TITLE
feat: include calculate_time in the module

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,14 @@ require('time-calculator').setup({
 })
 ```
 
+**Programmatic use:**
+
+```lua
+require('time-calculator').calculate_time()
+```
+
+Use it to e.g. set a custom keybinding with [`which-key.nvim`](https://github.com/folke/which-key.nvim) or [`lazy.nvim`](https://lazy.folke.io/).
+
 ---
 
 Use this plugin only for its intended purpose!

--- a/lua/time-calculator.lua
+++ b/lua/time-calculator.lua
@@ -58,7 +58,7 @@ local set_node_text = function(node, text)
 	)
 end
 
-local calculate_time = function()
+M.calculate_time = function()
 	local parsed = vim.treesitter.query.parse(
 		'markdown',
 		[[
@@ -150,7 +150,7 @@ M.setup = function(opts)
 	vim.keymap.set(
 		options.mode,
 		options.keymap,
-		calculate_time,
+		M.calculate_time,
 		{ desc = options.desc }
 	)
 end


### PR DESCRIPTION
This way it can be called manually with
`require("time-calculator").calculate_time()`.