### PR TITLE
feat: allow unsetting keymap

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,8 @@ require('time-calculator').setup({
 })
 ```
 
+Or you can set `keymap` to `nil` to disable the mapping completely.
+
 **Programmatic use:**
 
 ```lua

--- a/lua/time-calculator.lua
+++ b/lua/time-calculator.lua
@@ -129,7 +129,7 @@ M.calculate_time = function()
 end
 
 ---@class CalculateOpts
----@field keymap string
+---@field keymap string | nil
 ---@field mode string | string[]
 ---@field desc string
 
@@ -147,12 +147,14 @@ M.setup = function(opts)
 	---@type CalculateOpts
 	options = vim.tbl_extend('force', options, opts)
 
-	vim.keymap.set(
-		options.mode,
-		options.keymap,
-		M.calculate_time,
-		{ desc = options.desc }
-	)
+	if options.keymap ~= nil then
+		vim.keymap.set(
+			options.mode,
+			options.keymap,
+			M.calculate_time,
+			{ desc = options.desc }
+		)
+	end
 end
 
 return M


### PR DESCRIPTION
Setting keymap to nil skips setting the keymap so user can set it up
however they want. Like using which-key or Lazy PluginSpec.